### PR TITLE
Pages for domain index and cookiecutter-data-science

### DIFF
--- a/cookiecutter-data-science/index.html
+++ b/cookiecutter-data-science/index.html
@@ -7,9 +7,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="author" content="DrivenData" />
   <link rel="icon" href="https://drivendata-public-assets.s3.amazonaws.com/drivendata-favicon.ico">
-  <meta http-equiv="refresh" content="8; URL=https://cookiecutter-data-science.drivendata.org/" />
+  <meta http-equiv="refresh" content="0; URL=https://cookiecutter-data-science.drivendata.org/" />
   <link rel="canonical" href="https://cookiecutter-data-science.drivendata.org/" />
   <style>
+    body {
+      display: none;
+    }
+
     .main {
       margin-top: 5em;
       display: flex;
@@ -18,20 +22,32 @@
     }
 
     .content {
-      padding: 1em;
-      border: 1px dotted rgb(24, 52, 74);
-      ;
       color: rgb(24, 52, 74);
-      font-size: 18px;
+      font-size: 14px;
       font-family: Helvetica, Arial, sans-serif;
       line-height: 1.75em;
-      max-width: 40em;
+      max-width: 840px;
+      text-align: center;
+    }
+
+    .intro {
+      padding: 1em;
+    }
+
+    .notice {
+      font-size: 1.33em;
+      padding: 1em;
+      border: 1px dotted rgb(24, 52, 74);
     }
 
     .content h1 {
-      font-size: 3em;
+      font-size: 1.75em;
       font-weight: 400;
-      font-family: Helvetica, Arial, sans-serif;
+    }
+
+    .content h2 {
+      font-size: 2.25em;
+      font-weight: 400;
     }
   </style>
 </head>
@@ -39,22 +55,23 @@
 <body>
   <div class="main">
     <div class="content">
+      <div class="intro">
       <h1>Cookiecutter Data Science</h1>
       <p>
         <i>A logical, flexible, and reasonably standardized project structure for doing and sharing data science
           work.</i>
       </p>
-      <h2>We've moved!</h2>
-      <p>
-        Cookiecutter Data Science has moved to a new domain:
-      </p>
-      <p>
-        <a
-          href="https://cookiecutter-data-science.drivendata.org/">https://cookiecutter-data-science.drivendata.org/</a>
-      </p>
-      <p>
-        You should be redirected there automatically in a few seconds.
-      </p>
+      </div>
+      <div class="notice">
+        <h2>We've moved!</h2>
+        <p>
+          <a
+            href="https://cookiecutter-data-science.drivendata.org/">https://cookiecutter-data-science.drivendata.org/</a>
+        </p>
+        <p>
+          You will be redirected in a few seconds.
+        </p>
+      </div>
     </div>
   </div>
 </body>

--- a/cookiecutter-data-science/index.html
+++ b/cookiecutter-data-science/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>Cookecutter Data Science</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="author" content="DrivenData" />
+  <link rel="icon" href="https://drivendata-public-assets.s3.amazonaws.com/drivendata-favicon.ico">
+  <meta http-equiv="refresh" content="8; URL=https://cookiecutter-data-science.drivendata.org/" />
+  <link rel="canonical" href="https://cookiecutter-data-science.drivendata.org/" />
+  <style>
+    .main {
+      margin-top: 5em;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .content {
+      padding: 1em;
+      border: 1px dotted rgb(24, 52, 74);
+      ;
+      color: rgb(24, 52, 74);
+      font-size: 18px;
+      font-family: Helvetica, Arial, sans-serif;
+      line-height: 1.75em;
+      max-width: 40em;
+    }
+
+    .content h1 {
+      font-size: 3em;
+      font-weight: 400;
+      font-family: Helvetica, Arial, sans-serif;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="main">
+    <div class="content">
+      <h1>Cookiecutter Data Science</h1>
+      <p>
+        <i>A logical, flexible, and reasonably standardized project structure for doing and sharing data science
+          work.</i>
+      </p>
+      <h2>We've moved!</h2>
+      <p>
+        Cookiecutter Data Science has moved to a new domain:
+      </p>
+      <p>
+        <a
+          href="https://cookiecutter-data-science.drivendata.org/">https://cookiecutter-data-science.drivendata.org/</a>
+      </p>
+      <p>
+        You should be redirected there automatically in a few seconds.
+      </p>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/cookiecutter-data-science/index.html
+++ b/cookiecutter-data-science/index.html
@@ -56,11 +56,11 @@
   <div class="main">
     <div class="content">
       <div class="intro">
-      <h1>Cookiecutter Data Science</h1>
-      <p>
-        <i>A logical, flexible, and reasonably standardized project structure for doing and sharing data science
-          work.</i>
-      </p>
+        <h1>Cookiecutter Data Science</h1>
+        <p>
+          <i>A logical, flexible, and reasonably standardized project structure for doing and sharing data science
+            work.</i>
+        </p>
       </div>
       <div class="notice">
         <h2>We've moved!</h2>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="author" content="DrivenData" />
   <link rel="icon" href="https://drivendata-public-assets.s3.amazonaws.com/drivendata-favicon.ico">
-  <meta http-equiv="refresh" content="3; URL=https://drivendata.co/" />
+  <meta http-equiv="refresh" content="0; URL=https://drivendata.co/" />
   <link rel="canonical" href="https://drivendata.co/" />
   <meta name="robots" content="noindex" />
   <style>
@@ -16,10 +16,10 @@
     }
 
     .main {
-      margin-top: 5em;
-      display: flex;
+      display: none; /* flex */
       align-items: center;
       justify-content: center;
+      margin-top: 5em;
     }
 
     .content {

--- a/index.html
+++ b/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <title>DrivenData Labs</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="author" content="DrivenData" />
+  <link rel="icon" href="https://drivendata-public-assets.s3.amazonaws.com/drivendata-favicon.ico">
+  <meta http-equiv="refresh" content="3; URL=https://drivendata.co/" />
+  <link rel="canonical" href="https://drivendata.co/" />
+  <meta name="robots" content="noindex" />
+  <style>
+    body {
+      background-color: rgb(23, 52, 74);
+    }
+
+    .main {
+      margin-top: 5em;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .content {
+      padding: 1em;
+      color: rgb(245, 245, 245);
+      font-size: 20px;
+      font-family: Helvetica, Arial, sans-serif;
+      ;
+      line-height: 1.75em;
+      max-width: 40em;
+      text-align: center;
+    }
+
+    .content h1 {
+      font-size: 3em;
+      font-weight: 400;
+      display: none;
+    }
+
+    .content h2 {
+      font-weight: bold;
+    }
+
+    .content a:link,
+    .content a:visited,
+    .content a:hover,
+    .content a:active {
+      color: rgb(3, 169, 244);
+      text-decoration: none;
+    }
+
+    .content a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="main">
+    <div class="content">
+      <a href="https://drivendata.co"><img
+          src="https://drivendata-public-assets.s3.amazonaws.com/drivendata-logo-white.svg" alt="DrivenData Labs"
+          height="48"></a>
+      <h1>DrivenData Labs</h1>
+      <h2>Building data and AI solutions for problems that matter.</h2>
+      <p>
+        Our website is located at <a href="https://drivendata.co">https://drivendata.co</a>. You will be directed in a
+        few seconds.
+      </p>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
     }
 
     .main {
-      display: none; /* flex */
+      display: none;
+      /* display: flex; */
       align-items: center;
       justify-content: center;
       margin-top: 5em;


### PR DESCRIPTION
This PR has a static page that would be served at <https://drivendata.github.io/cookie-cutter-data-science>. (We should be able to safely merge; it has lower priority than GitHub Pages served from the drivendata/cookiecutter-data-science repo.)

This is a blank white page that may flash and then should immediately redirect. 

Some notes:

- There's some real hidden content on the page that I originally tried playing around with, and the display is hidden with CSS. I think it may be worth keeping for the search engines? 
- I've added a `rel="canonical"` reference to the new location ([reference](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method)). Hopefully this helps with SEO? 

Bonus:

- I've added a similar page for <https://drivendata.github.io> that redirects to <https://drivendata.co>. Blank via CSS and redirects immediately. This page also has a `noindex` for search engines. The status quo right now is that <https://drivendata.github.io> is a 404 error. 
